### PR TITLE
Update GitHub Actions runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     concurrency:


### PR DESCRIPTION
ubuntu-20.04->22.04へ変更